### PR TITLE
Fix Psi-Warrior formatting

### DIFF
--- a/Content/pub_20201117_TCoE-WIP_3P.js
+++ b/Content/pub_20201117_TCoE-WIP_3P.js
@@ -1071,8 +1071,7 @@ regExpSearch: /^(?=.*(fighter))(?=.*(psi))(?=.*(warrior)).*$/i,
 			Source : ["TCoE",43],
 			minlevel : 3,
 			description : desc([
-				"Once per",
-				"short rest, I can regain one expended PsiD as a bonus action"
+				"Once per short rest, I can regain one expended PsiD as a bonus action"
 			]),
 			action : ["bonus acttion","regain 1 Psionic Energy die"],
 			usages : 1,


### PR DESCRIPTION
Removed egregious line break in text for Psi-Warrior's regain psionic energy dice- now the text fits on one line

### Checklist
- [x] This box is checked
- [x] Correctly formatted on Printer-Friendly sheet
- [x] Correctly formatted on Colourful sheet
