### PR TITLE
Update Crusher feat description

### DIFF
--- a/Content/pub_20201117_TCoE-WIP_3P.js
+++ b/Content/pub_20201117_TCoE-WIP_3P.js
@@ -5900,7 +5900,7 @@ FeatsList["crusher"] = {
 	name: "Crusher",
 	source: ["TCoE"],
 	descriptionFull : "You are practiced in the art of crushing your enemies, granting you the following benefits:\n \u2022Increase your Strength or Constitution by 1, to a maximum of 20.\n \u2022Once per turn, when you hit a creature with an attack that deals bludgeoning damage, you can move it 5 feet to an unoccupied space, provided the target is no more than one size larger than you.\n \u2022When you score a critical hit that deals bludgeoning damage to a creature, attack rolls against that creature are made with advantage until the start of your next turn.",
-	description: "Once per turn when I deal bludgeoning damage to a target, I can move it 5 feet if it is less than 1 size larger than me. If I deal bludgeoning damage on a critical hit to a target attack rolls against it are with advantage until start of my next turn. [+1 Strength or Constitution]",
+	description: (typePF ? "Once per turn, when I hit a creature with an attack that deals bludgeoning damage, I can move it 5 ft to an unoccupied space, if it is no more than one size larger than me. On a critical hit that deals bludgeoning damage to a creature, attacks vs. it have adv. until the start of my next turn. [+1 Strength or Constitution]" : "Once per turn, when I hit a creature with bludg. attack, I can move it 5 ft to an unoccupied space, if it is no more than one size larger than me. On a critical bludg. hit on a creature, attacks vs. it have adv. until the start of my next turn. [+1 Str or Con]"),
 	improvements: "Crusher (feat): +1 Strength or Constitution;"
 };
 FeatsList["eldritch adept"] = { // <-- not complete


### PR DESCRIPTION
Update Crusher feat description to be grammatically correct and align more with the feat as described in Tasha's.

The original description also overflowed on the colorful sheet, so I also added a description that fits on the colorful sheet.

<!-- Please include a brief description of the feature (class, race, etc.) that you're adding and complete the checklist below. Thank you. -->

### Example
Added the following features for Psionic Options Revisited:
- Psi Knight Fighter subclass
- Soulknife Rogue subclass
- Psionic Soul Sorcerer subclass
- Mind Sliver cantrip
- Mind Thrust spell
- Intellect Fortress spell
- Wild Talent feat
- Tower of Iron Will feat
- Telepathic feat
- Telekinetic feat
- Metabollic Control feat

### Checklist
- [x] This box is checked
- [X] Correctly formatted on Printer-Friendly sheet
- [X] Correctly formatted on Colourful sheet
