### PR TITLE
Bard's College of Creation fix

### DIFF
--- a/Content/pub_20201117_TCoE-WIP_3P.js
+++ b/Content/pub_20201117_TCoE-WIP_3P.js
@@ -309,7 +309,7 @@ AddSubClass("bard", "college of creation", {
 				"\u2022 Ability Check: Roll the die twice and choose which result to use"
 			])
 		},
-		"subclassfeature3" : {
+		"subclassfeature3.1" : {
 			name : "Performance of Creation",
 			source : [["T", 26]],
 			minlevel : 3,


### PR DESCRIPTION
Bard's subclass "College of Creation".
"Mote of Potential" was overwritten by "Performance of Creation" due to same object key.

### Checklist
- [x] Correctly formatted on Printer-Friendly sheet
- [x] Correctly formatted on Colourful sheet
